### PR TITLE
Fix logging, dynamic labels, correct datastore

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ customer: ""
 aml_experiment_details:
   compute_name: oor-testing
   env_name: oor-environment
-  env_version: 52
+  env_version: 57
   src_dir: "."
 
 convert_dataset:
@@ -15,7 +15,7 @@ convert_annotations:
   input_datastore_name: annotations_conversion_old
   output_datastore_name: annotations_conversion_new
   final_datastore_name: converted_new_dataset_oor
-  categories_file: categories.json
+  categories_file: categories_baas.json
   separate_labels: True
   label_folder: dataset_folder/labels
 
@@ -116,12 +116,12 @@ training_pipeline:
     name_classes: ["person", "license plate", "container", "mobile toilet", "scaffolding"]
     rect: False
   inputs:
-    datastore_path: "dataset_oor_v2_0"
-    training_data_rel_path: "processed-dataset-oor-v2-0"
+    datastore_path: "dataset_oor_v2_2"
+    training_data_rel_path: "processed-dataset-oor-v2-2"
     model_weights_rel_path: "model"
-    model_name: "best_yolov8m_coco_290524_old_oor_nc_5.pt"
+    model_name: "best_yolo11m_coco_161024.pt"
   outputs:
-    project_datastore_path: "dataset_oor_v2_0"
+    project_datastore_path: "dataset_oor_v2_2"
     project_rel_path: "model"
 
 sweep_pipeline:
@@ -135,13 +135,13 @@ sweep_pipeline:
     rect: False
   sweep_trials: 30
   inputs:
-    datastore_path: "dataset_oor_v2_0"
-    training_data_rel_path: "processed-dataset-oor-v2-0"
+    datastore_path: "dataset_oor_v2_2"
+    training_data_rel_path: "processed-dataset-oor-v2-2"
     model_weights_rel_path: "model"
-    model_name: "best_yolov8m_coco_290524_old_oor_nc_5.pt"
+    model_name: "best_yolo11m_coco_161024.pt"
     sweep_config: "sweep_config.json"
   outputs:
-    project_datastore_path: "dataset_oor_v2_0"
+    project_datastore_path: "dataset_oor_v2_2"
     project_rel_path: "model"
 
 wandb:
@@ -150,10 +150,10 @@ wandb:
 
 logging:
   loglevel_own: DEBUG  # override loglevel for packages defined in `own_packages`
-  own_packages: ["__main__", "objectherkenning_openbare_ruimte", "convert_annotations", "inference_pipeline", "performance_evaluation"]
+  own_packages: ["__main__", "objectherkenning_openbare_ruimte", "convert_annotations_pipeline", "inference_pipeline", "performance_evaluation"]
   basic_config:
     # log config as arguments to `logging.basicConfig`
     level: WARNING
     format: "%(asctime)s|||%(levelname)-8s|%(name)s|%(message)s"
     datefmt: "%Y-%m-%d %H:%M:%S"
-  ai_instrumentation_key: "AI_INSTRUMENTATION_KEY"
+  ai_instrumentation_key: ""

--- a/config.yml
+++ b/config.yml
@@ -156,4 +156,4 @@ logging:
     level: WARNING
     format: "%(asctime)s|||%(levelname)-8s|%(name)s|%(message)s"
     datefmt: "%Y-%m-%d %H:%M:%S"
-  ai_instrumentation_key: ""
+  ai_instrumentation_key: "AI_INSTRUMENTATION_KEY"

--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,7 @@ convert_annotations:
   input_datastore_name: annotations_conversion_old
   output_datastore_name: annotations_conversion_new
   final_datastore_name: converted_new_dataset_oor
+  image_storage_account: cvodataweupgwapeg4pyiw5e
   categories_file: categories.json
   separate_labels: True
   label_folder: dataset_folder/labels

--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ convert_annotations:
   input_datastore_name: annotations_conversion_old
   output_datastore_name: annotations_conversion_new
   final_datastore_name: converted_new_dataset_oor
-  categories_file: categories_baas.json
+  categories_file: categories.json
   separate_labels: True
   label_folder: dataset_folder/labels
 

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/components/convert_annotations.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/components/convert_annotations.py
@@ -2,13 +2,15 @@ import logging
 import os
 import sys
 
+from aml_interface.azure_logging import AzureLoggingConfigurer
 from azure.ai.ml.constants import AssetTypes
 from mldesigner import Input, Output, command_component
 
 sys.path.append("../../..")
 
-from aml_interface.azure_logging import setup_azure_logging  # noqa: E402
-
+from objectherkenning_openbare_ruimte.convert_annotations_pipeline.source.yolo_to_azure_coco_converter import (  # noqa: E402
+    YoloToAzureCocoConverter,
+)
 from objectherkenning_openbare_ruimte.settings.settings import (  # noqa: E402
     ObjectherkenningOpenbareRuimteSettings,
 )
@@ -16,17 +18,14 @@ from objectherkenning_openbare_ruimte.settings.settings import (  # noqa: E402
 config_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "config.yml")
 )
-settings = ObjectherkenningOpenbareRuimteSettings.set_from_yaml(config_path)
-log_settings = ObjectherkenningOpenbareRuimteSettings.set_from_yaml(config_path)[
-    "logging"
-]
-setup_azure_logging(log_settings, __name__)
-aml_experiment_settings = settings["aml_experiment_details"]
-logger = logging.getLogger("convert_annotations")
+ObjectherkenningOpenbareRuimteSettings.set_from_yaml(config_path)
+settings = ObjectherkenningOpenbareRuimteSettings.get_settings()
 
-from objectherkenning_openbare_ruimte.convert_annotations_pipeline.source.yolo_to_azure_coco_converter import (  # noqa: E402
-    YoloToAzureCocoConverter,
-)
+azure_logging_configurer = AzureLoggingConfigurer(settings["logging"])
+azure_logging_configurer.setup_oor_logging()
+logger = logging.getLogger("convert_annotations_pipeline")
+
+aml_experiment_settings = settings["aml_experiment_details"]
 
 
 @command_component(

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/components/convert_annotations.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/components/convert_annotations.py
@@ -39,6 +39,7 @@ def convert_annotations(
     input_old_folder: Input(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821
     output_new_folder: Output(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821
     datastore_name: str,
+    image_storage_account: str,
     categories_file: str,
     separate_labels: bool = False,
     label_folder: str = None,
@@ -54,6 +55,8 @@ def convert_annotations(
         Path to the folder containing the converted annotations.
     datastore_name: str
         Name of the datastore of the dataset.
+    image_storage_account: str
+        Name of the storage account of the dataset.
     categories_file: str
         Path to the JSON file containing the categories.
     separate_labels: bool, optional
@@ -66,6 +69,7 @@ def convert_annotations(
     logger.info(f"Input folder: {input_old_folder}")
     logger.info(f"Output folder: {output_new_folder}")
     logger.info(f"Datastore name: {datastore_name}")
+    logger.info(f"Image storage account: {image_storage_account}")
     logger.info(f"Categories file: {categories_file}")
     logger.info(f"Separate labels: {separate_labels}")
 
@@ -80,6 +84,7 @@ def convert_annotations(
         input_old_folder,
         output_new_folder,
         datastore_name,
+        image_storage_account,
         categories_file,
         separate_labels,
         label_folder_path,

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/source/yolo_to_azure_coco_converter.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/source/yolo_to_azure_coco_converter.py
@@ -20,6 +20,7 @@ class YoloToAzureCocoConverter:
         input_folder: str,
         output_folder: str,
         datastore_name: str,
+        image_storage_account: str,
         categories_file: str,
         separate_labels: bool = False,
         label_folder: str = None,
@@ -33,12 +34,15 @@ class YoloToAzureCocoConverter:
             Path to the folder where the Azure COCO annotations will be stored.
         datastore_name: str
             Name of the datastore to be used in the COCO file URLs.
+        image_storage_account: str
+            Name of the storage account to be used in the COCO file URLs.
         categories_file: str
             Path to the JSON file containing the categories.
         """
         self.input_folder = input_folder
         self.output_folder = output_folder
         self.datastore_name = datastore_name
+        self.image_storage_account = image_storage_account
         self.separate_labels = separate_labels
         self.label_folder = label_folder if separate_labels else input_folder
         self._load_categories(categories_file)
@@ -167,7 +171,7 @@ class YoloToAzureCocoConverter:
             )
             file_name_formatted = f"{folder_name}/{file_name}"
             coco_url = f"AmlDatastore://{self.datastore_name}/{file_name_formatted}"
-            absolute_url = f"https://cvodataweupgwapeg4pyiw5e.blob.core.windows.net/{self.datastore_name}/{file_name_formatted.replace(' ', '%20')}"
+            absolute_url = f"https://{self.image_storage_account}.blob.core.windows.net/{self.datastore_name}/{file_name_formatted.replace(' ', '%20')}"
 
             self.coco_json["images"].append(
                 {

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/source/yolo_to_azure_coco_converter.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/source/yolo_to_azure_coco_converter.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import cv2
 from cvtoolkit.helpers.file_helpers import find_image_paths  # noqa: E402
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("convert_annotations_pipeline")
 
 
 class YoloToAzureCocoConverter:
@@ -123,9 +123,10 @@ class YoloToAzureCocoConverter:
         dict
             The annotation in COCO format.
         """
-        class_id, x_center, y_center, width, height = map(
-            float, yolo_annotation.split()
-        )
+        # Split the annotation and select only the first 5 values
+        values = yolo_annotation.split()[:5]
+        class_id, x_center, y_center, width, height = map(float, values)
+
         class_id += 1  # Azure COCO expects classes to start from 1
         x_center, y_center, width, height = (
             x_center * img_width,
@@ -166,7 +167,7 @@ class YoloToAzureCocoConverter:
             )
             file_name_formatted = f"{folder_name}/{file_name}"
             coco_url = f"AmlDatastore://{self.datastore_name}/{file_name_formatted}"
-            absolute_url = f"https://cvoamlweupgwapeg4pyiw5e7.blob.core.windows.net/{self.datastore_name}/{file_name_formatted.replace(' ', '%20')}"
+            absolute_url = f"https://cvodataweupgwapeg4pyiw5e.blob.core.windows.net/{self.datastore_name}/{file_name_formatted.replace(' ', '%20')}"
 
             self.coco_json["images"].append(
                 {

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/submit_convert_annotations.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/submit_convert_annotations.py
@@ -28,6 +28,7 @@ def convert_annotations_pipeline():
     )
 
     final_datastore_name = settings["convert_annotations"]["final_datastore_name"]
+    image_storage_account = settings["convert_annotations"]["image_storage_account"]
     categories_file = settings["convert_annotations"]["categories_file"]
     separate_labels = settings["convert_annotations"]["separate_labels"]
     label_folder = settings["convert_annotations"]["label_folder"]
@@ -35,6 +36,7 @@ def convert_annotations_pipeline():
     convert_annotations_step = convert_annotations(
         input_old_folder=input_old_input,
         datastore_name=final_datastore_name,
+        image_storage_account=image_storage_account,
         categories_file=categories_file,
         separate_labels=separate_labels,
         label_folder=label_folder,

--- a/objectherkenning_openbare_ruimte/convert_annotations_pipeline/submit_convert_annotations.py
+++ b/objectherkenning_openbare_ruimte/convert_annotations_pipeline/submit_convert_annotations.py
@@ -1,4 +1,3 @@
-from aml_interface.azure_logging import setup_azure_logging  # noqa: E402
 from azure.ai.ml import Input, Output
 from azure.ai.ml.constants import AssetTypes
 from azure.ai.ml.dsl import pipeline
@@ -12,7 +11,6 @@ from objectherkenning_openbare_ruimte.settings.settings import (
 
 ObjectherkenningOpenbareRuimteSettings.set_from_yaml("config.yml")
 settings = ObjectherkenningOpenbareRuimteSettings.get_settings()
-setup_azure_logging(settings["logging"], __name__)
 
 from aml_interface.aml_interface import AMLInterface  # noqa: E402
 

--- a/objectherkenning_openbare_ruimte/settings/settings_schema.py
+++ b/objectherkenning_openbare_ruimte/settings/settings_schema.py
@@ -26,6 +26,7 @@ class ConvertAnnotations(SettingsSpecModel):
     input_datastore_name: str = "annotations_conversion_old"
     output_datastore_name: str = "annotations_conversion_new"
     final_datastore_name: str = "converted-dataset-oor"
+    image_storage_account: str = "cvodataweupgwapeg4pyiw5e"
     categories_file: str = "categories.json"
     separate_labels: bool = False
     label_folder: str = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -2819,6 +2819,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = false
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
     {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
 ]
 
@@ -2829,6 +2830,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = false
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd"},
     {file = "pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c"},
 ]
 
@@ -4348,18 +4350,18 @@ files = [
 
 [[package]]
 name = "ultralytics"
-version = "8.3.1"
+version = "8.3.13"
 description = "Ultralytics YOLO for SOTA object detection, multi-object tracking, instance segmentation, pose estimation and image classification."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ultralytics-8.3.1-py3-none-any.whl", hash = "sha256:dc29d5dc7b6bbbd7d8f20baee54ff7a38a422c5fb2e954ebdf314885eaba3756"},
-    {file = "ultralytics-8.3.1.tar.gz", hash = "sha256:ced0d457f6a3f8c7cf217d2a6e66e655d21b76589c79859194711e7f1e62cecc"},
+    {file = "ultralytics-8.3.13-py3-none-any.whl", hash = "sha256:1b3218c0a69e776ce92fa2195cecf36bfb6d3434faa1ca95521a5df7510747fe"},
+    {file = "ultralytics-8.3.13.tar.gz", hash = "sha256:f4310b1c0ab259afb45d9adb900864a506c2909d70ddc33568fd10b4f74fdd92"},
 ]
 
 [package.dependencies]
 matplotlib = ">=3.3.0"
-numpy = ">=1.23.0,<2.0.0"
+numpy = ">=1.23.0"
 opencv-python = ">=4.6.0"
 pandas = ">=1.1.4"
 pillow = ">=7.1.2"
@@ -4379,10 +4381,10 @@ ultralytics-thop = ">=2.0.0"
 
 [package.extras]
 dev = ["coverage[toml]", "ipython", "mkdocs (>=1.6.0)", "mkdocs-jupyter", "mkdocs-macros-plugin (>=1.0.5)", "mkdocs-material (>=9.5.9)", "mkdocs-redirects", "mkdocs-ultralytics-plugin (>=0.1.8)", "mkdocstrings[python]", "pytest", "pytest-cov"]
-explorer = ["duckdb (<=0.9.2)", "lancedb", "streamlit"]
-export = ["coremltools (>=7.0)", "flatbuffers (>=23.5.26,<100)", "h5py (!=3.11.0)", "keras", "numpy (==1.23.5)", "onnx (>=1.12.0)", "openvino (>=2024.0.0)", "tensorflow (>=2.0.0)", "tensorflowjs (>=3.9.0)", "tensorstore (>=0.1.63)"]
+export = ["coremltools (>=7.0)", "flatbuffers (>=23.5.26,<100)", "h5py (!=3.11.0)", "keras", "numpy (==1.23.5)", "onnx (>=1.12.0)", "openvino (>=2024.0.0)", "scikit-learn (>=1.3.2)", "tensorflow (>=2.0.0)", "tensorflowjs (>=3.9.0)", "tensorstore (>=0.1.63)"]
 extra = ["albumentations (>=1.4.6)", "hub-sdk (>=0.0.12)", "ipython", "pycocotools (>=2.0.7)"]
 logging = ["comet", "dvclive (>=2.12.0)", "tensorboard (>=2.13.0)"]
+solutions = ["shapely (>=2.0.0)", "streamlit"]
 
 [[package]]
 name = "ultralytics-thop"


### PR DESCRIPTION
The PR includes small changes in the code:
- logging now works in AML
- the script only takes the first 5 values in the labels file, so it doesn't matter if we include confidence score or anything else after the relevant values
- the .json contains the correct datastore in the image paths (cvodata instead of cvoaml)