### PR TITLE
Update ref_db table name

### DIFF
--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/data_enrichment_step/components/decos_data_connector.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/data_enrichment_step/components/decos_data_connector.py
@@ -35,7 +35,7 @@ class DecosDataHandler(ReferenceDatabaseConnector):
         """
         Process the results of the query.
         """
-        query = f"SELECT id, kenmerk, locatie, geometrie_locatie, objecten FROM vergunningen_werk_en_vervoer_op_straat WHERE datum_object_van <= '{date_to_query}' AND datum_object_tm >= '{date_to_query}'"  # nosec B608
+        query = f"SELECT id, kenmerk, locatie, geometrie_locatie, objecten FROM vergunningen_werk_en_vervoer_op_straat_v2 WHERE datum_object_van <= '{date_to_query}' AND datum_object_tm >= '{date_to_query}'"  # nosec B608
         print(f"Querying the database for date {date_to_query}...")
         result_df = self.run(query)
 


### PR DESCRIPTION
Tables in the ref_db now have a version number appended. The name without a version is a view, which technically should work too but for now has some permission issues. Once the view has been fixed, we can go back to that so we always have the last version.