### PR TITLE
Add option to specify start time for sending signals

### DIFF
--- a/objectherkenning_openbare_ruimte/databricks_pipelines/common/__init__.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/common/__init__.py
@@ -10,6 +10,7 @@ from .utils_arg_parser import (
     parse_manual_run_arg_to_settings,
     parse_skip_ids_arg_to_settings,
     parse_task_args_to_settings,
+    parse_time_arg_to_settings,
     setup_arg_parser,
 )
 from .utils_images import OutputImage

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/common/utils_arg_parser.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/common/utils_arg_parser.py
@@ -10,6 +10,7 @@ def setup_arg_parser(prog: str = __name__) -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(prog=prog)
     parser.add_argument("--detection_date", type=str, default="", help="yyyy-mm-dd")
+    parser.add_argument("--send_after_time", type=str, default="", help="HH:MM")
     parser.add_argument(
         "--manual_inspection",
         type=ast.literal_eval,
@@ -208,5 +209,37 @@ def parse_detection_date_arg_to_settings(
             raise e
     else:
         settings["job_config"]["detection_date"] = None
+
+    return settings
+
+
+def parse_time_arg_to_settings(
+    settings: dict[str, Any], args: argparse.Namespace
+) -> dict[str, Any]:
+    """
+    Parse the send_after_time command line argument and update settings.
+
+    Parameters
+    ----------
+    settings: dict[str, Any]
+        Full databricks config settings.
+    args: argparse.Namespace
+        Command line arguments
+
+    Returns
+    -------
+    Updated settings dict
+    """
+
+    if args.send_after_time:
+        try:
+            settings["job_config"]["send_after_time"] = datetime.datetime.strptime(
+                args.send_after_time, "%H:%M"
+            ).time()
+        except ValueError as e:
+            print(f"Incorrect time format, expected HH:MM, got {args.detection_date}")
+            raise e
+    else:
+        settings["job_config"]["send_after_time"] = None
 
     return settings

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
@@ -73,8 +73,8 @@ class SubmitToSignalenStep:
             start_time_str = self.send_after_time.strftime("%H:%M")
             cur_time_str = datetime.datetime.now(datetime.UTC).strftime("%H:%M")
             print(
-                f"Waiting for starting time: {start_time_str}\n"
-                f"Current time: {cur_time_str}"
+                f"\nWaiting for starting time: {start_time_str}"
+                f"\nCurrent time: {cur_time_str}"
             )
 
             while datetime.datetime.now(datetime.UTC).time() < self.send_after_time:

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
@@ -1,5 +1,5 @@
+import datetime
 import time
-from datetime import _Date, _Time, datetime, timezone
 from typing import Any, Optional
 
 from pyspark.sql import SparkSession
@@ -36,10 +36,10 @@ class SubmitToSignalenStep:
         self.az_tenant_id = settings["azure_tenant_id"]
         self.db_host = settings["reference_database"]["host"]
         self.db_name = settings["reference_database"]["name"]
-        self.send_after_time: Optional[_Time] = settings["job_config"].get(
+        self.send_after_time: Optional[datetime.time] = settings["job_config"].get(
             "send_after_time", None
         )
-        self.detection_date: Optional[_Date] = settings["job_config"].get(
+        self.detection_date: Optional[datetime.datetime] = settings["job_config"].get(
             "detection_date", None
         )
         self.exclude_private_terrain_detections = settings["job_config"][
@@ -71,13 +71,13 @@ class SubmitToSignalenStep:
 
         if self.send_after_time is not None:
             start_time_str = self.send_after_time.strftime("%H:%M")
-            cur_time_str = datetime.now(timezone.utc).strftime("%H:%M")
+            cur_time_str = datetime.datetime.now(datetime.UTC).strftime("%H:%M")
             print(
                 f"Waiting for starting time: {start_time_str}\n"
                 f"Current time: {cur_time_str}"
             )
 
-            while datetime.now(timezone.utc).time() < self.send_after_time:
+            while datetime.datetime.now(datetime.UTC).time() < self.send_after_time:
                 time.sleep(60)
 
         active_stadsdelen = self.active_task_config.keys()

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/components/submit_to_signalen_step.py
@@ -1,4 +1,6 @@
-from typing import Any
+import time
+from datetime import _Date, _Time, datetime, timezone
+from typing import Any, Optional
 
 from pyspark.sql import SparkSession
 
@@ -34,7 +36,12 @@ class SubmitToSignalenStep:
         self.az_tenant_id = settings["azure_tenant_id"]
         self.db_host = settings["reference_database"]["host"]
         self.db_name = settings["reference_database"]["name"]
-        self.detection_date = settings["job_config"].get("detection_date", None)
+        self.send_after_time: Optional[_Time] = settings["job_config"].get(
+            "send_after_time", None
+        )
+        self.detection_date: Optional[_Date] = settings["job_config"].get(
+            "detection_date", None
+        )
         self.exclude_private_terrain_detections = settings["job_config"][
             "exclude_private_terrain_detections"
         ]
@@ -61,6 +68,18 @@ class SubmitToSignalenStep:
         one. Set test_only to True to skip actually sending signals, for testing
         purposes.
         """
+
+        if self.send_after_time is not None:
+            start_time_str = self.send_after_time.strftime("%H:%M")
+            cur_time_str = datetime.now(timezone.utc).strftime("%H:%M")
+            print(
+                f"Waiting for starting time: {start_time_str}\n"
+                f"Current time: {cur_time_str}"
+            )
+
+            while datetime.now(timezone.utc).time() < self.send_after_time:
+                time.sleep(60)
+
         active_stadsdelen = self.active_task_config.keys()
 
         for stadsdeel in active_stadsdelen:

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/run_submit_to_signalen_step.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/run_submit_to_signalen_step.py
@@ -10,6 +10,7 @@ from objectherkenning_openbare_ruimte.databricks_pipelines.common import (
     parse_manual_run_arg_to_settings,
     parse_skip_ids_arg_to_settings,
     parse_task_args_to_settings,
+    parse_time_arg_to_settings,
     setup_arg_parser,
     setup_tables,
 )
@@ -25,6 +26,7 @@ def parse_args_to_settings(
     settings: Dict[str, Any], args: argparse.Namespace
 ) -> Dict[str, Any]:
     settings = parse_task_args_to_settings(settings, args)
+    settings = parse_time_arg_to_settings(settings, args)
     settings = parse_detection_date_arg_to_settings(settings, args)
     settings = parse_skip_ids_arg_to_settings(settings, args)
     settings = parse_manual_run_arg_to_settings(settings, args)
@@ -53,12 +55,14 @@ def main(args: argparse.Namespace) -> None:
         stadsdeel_str = str(settings["job_config"]["active_task"][stadsdeel])
         print(f"  - {stadsdeel}: {stadsdeel_str}")
     if settings["job_config"]["detection_date"] is not None:
-        print(
-            f"  - will only process pending detections for date {settings['job_config']['detection_date']}"
-        )
+        datestr = settings["job_config"]["detection_date"].strftime(format="%Y-%m-%d")
+        print(f"  - will only process pending detections for date {datestr}")
     if len(settings["job_config"]["skip_ids"]) > 0:
         id_str = ", ".join(map(str, settings["job_config"]["skip_ids"]))
         print(f"  - will skip detection IDs: [{id_str}]")
+    if settings["job_config"]["send_after_time"] is not None:
+        timestr = settings["job_config"]["detection_date"].strftime(format="%H:%M")
+        print(f"  - will send signals after {timestr}")
     print("\n")
 
     catalog = settings["catalog"]

--- a/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/run_submit_to_signalen_step.py
+++ b/objectherkenning_openbare_ruimte/databricks_pipelines/post_processing_pipeline/submit_to_signalen_step/run_submit_to_signalen_step.py
@@ -61,7 +61,7 @@ def main(args: argparse.Namespace) -> None:
         id_str = ", ".join(map(str, settings["job_config"]["skip_ids"]))
         print(f"  - will skip detection IDs: [{id_str}]")
     if settings["job_config"]["send_after_time"] is not None:
-        timestr = settings["job_config"]["detection_date"].strftime(format="%H:%M")
+        timestr = settings["job_config"]["send_after_time"].strftime(format="%H:%M")
         print(f"  - will send signals after {timestr}")
     print("\n")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "objectherkenning_openbare_ruimte"
-version = "2.2.9"
+version = "2.2.10"
 description = "Objectherkenning Openbare Ruimte is a project about recognising objects from public space images."
 authors = [
     {name = "Sebastian Davrieux", email = "s.davrieux@amsterdam.nl"},


### PR DESCRIPTION
New config parameter for the databricks job: `send_after_time`. This specifies the time (HH:MM, in UTC; e.g. "15:30") after which signals should be sent. The `submit_to_signalen` step will wait until that time before processing continues.